### PR TITLE
feat: Use OAuthProvider + McpAgent for native Cloudflare MCP OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
 # Polar MCP Server
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare)](https://workers.cloudflare.com/)
-[![MCP](https://img.shields.io/badge/MCP-Compatible-blue)](https://modelcontextprotocol.io/)
-
 An MCP (Model Context Protocol) server for the Polar AccessLink API. Connect your Polar fitness data to Claude AI - access workouts, sleep analysis, recovery metrics, heart rate data, and more.
 
 ## Quick Start (Public Instance)
 
 **No setup required!** Use our hosted instance:
 
-1. Visit **[polar-mcp-server.n-neuhaeusel.workers.dev](https://polar-mcp-server.n-neuhaeusel.workers.dev)**
-2. Click **"Connect with Polar"** and authorize with your Polar account
-3. Copy the MCP Server URL you receive
-4. In Claude: **Settings → Integrations → Add MCP Server**
-5. Paste the URL and start chatting about your fitness data!
+1. In Claude: **Settings → Integrations → Add MCP Server**
+2. Enter the URL: `https://polar-mcp-server.n-neuhaeusel.workers.dev/mcp`
+3. Claude will open an authorization window — log in with your Polar account
+4. Start chatting about your fitness data!
 
 ## Features
 
@@ -145,7 +140,6 @@ All tools use the [Polar AccessLink API v3](https://www.polar.com/accesslink-api
 
 | Error | Solution |
 |-------|----------|
-| "Session expired" | Visit `/authorize` again to create a new session |
 | "Polar API error (403)" | Re-authorize or check if data sync is complete |
 | "Polar API error (404)" | Endpoint not available for your device/subscription |
 | No exercise data | Sync your Polar device to Polar Flow app first |
@@ -153,8 +147,8 @@ All tools use the [Polar AccessLink API v3](https://www.polar.com/accesslink-api
 ## Privacy
 
 - Your Polar credentials are never stored
-- OAuth tokens are stored in Cloudflare KV with 24-hour expiration
-- Each user gets their own isolated session
+- OAuth tokens are managed securely by the Cloudflare Workers OAuth provider
+- Each user gets their own isolated MCP session
 - No fitness data is logged or stored on our servers
 
 ## Contributing

--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,124 @@
+# WARP.md
+
+This file provides guidance to WARP (warp.dev) when working with code in this repository.
+
+## Common commands
+
+All commands are intended to be run from the repository root.
+
+### Setup
+
+- Install dependencies:
+  - `npm install`
+- Required runtime:
+  - Node.js `>=18` (ESM, `type: "module"`)
+
+### Local MCP server (stdio, for Claude Desktop or CLI)
+
+- Build TypeScript to JavaScript (local MCP only):
+  - `npm run build`
+- Start the local MCP server (after building):
+  - `npm start`
+  - Entry point: `dist/index.js`, MCP server name `polar-accesslink`, requires `POLAR_ACCESS_TOKEN` env var.
+- During development, run the TypeScript entry directly:
+  - `npm run dev`
+  - Uses `tsx src/index.ts`.
+
+### OAuth helper for local access tokens
+
+- Run the local OAuth helper to obtain a `POLAR_ACCESS_TOKEN`:
+  - `npm run auth`
+  - Expects `POLAR_CLIENT_ID` and `POLAR_CLIENT_SECRET` in the environment; starts a local HTTP server on port `8888` and guides you through browser-based authorization.
+
+### Cloudflare Worker MCP server (remote, for claude.ai)
+
+The remote deployment is managed via Cloudflare Workers and Wrangler. Configuration lives in `wrangler.toml` (`main = "src/worker.ts"`).
+
+- Start a local dev server for the Worker:
+  - `npm run dev:worker`
+  - Uses `wrangler dev`, serving `src/worker.ts` and using the `env.dev` configuration in `wrangler.toml`.
+- Deploy the Worker to Cloudflare:
+  - `npm run deploy`
+- Configure Cloudflare KV (only needs to be done once per environment, not part of normal dev loop):
+  - Create a KV namespace and update `wrangler.toml` with the resulting IDs (see comments in that file).
+- Configure Worker secrets (one-time per environment):
+  - `npx wrangler secret put POLAR_CLIENT_ID`
+  - `npx wrangler secret put POLAR_CLIENT_SECRET`
+
+### Tests and linting
+
+- There is currently **no configured test or lint command** in `package.json` (no test runner dependencies or lint scripts). Do not assume `npm test`, `vitest`, or ESLint are available unless they are added explicitly.
+
+## Project architecture
+
+### Overview
+
+This repository implements a Model Context Protocol (MCP) server for the Polar AccessLink API with two deployment modes:
+
+1. **Local stdio MCP server** for Claude Desktop or any MCP-compatible client that launches a local binary.
+2. **Remote Cloudflare Worker-based MCP server** that can be connected from claude.ai via an HTTP/SSE MCP endpoint.
+
+Both modes share common Polar API helpers and tool definitions.
+
+### Entry points and deployment targets
+
+- **Local MCP server (Node.js / stdio)**
+  - Entry file: `src/index.ts`
+  - Built output: `dist/index.js` (via `npm run build` and `tsconfig.json`).
+  - Protocol: MCP over stdio using `@modelcontextprotocol/sdk` (`McpServer` + `StdioServerTransport`).
+  - Authentication: reads `POLAR_ACCESS_TOKEN` from the environment and uses it for all Polar API calls.
+
+- **Remote MCP server (Cloudflare Worker)**
+  - Entry file: `src/worker.ts`
+  - Configured in `wrangler.toml` as `main = "src/worker.ts"` with `nodejs_compat` enabled.
+  - Uses Cloudflare KV (`OAUTH_KV`) to store OAuth state and short-lived user sessions (mapping session IDs to access tokens and user IDs).
+  - Exposes several HTTP endpoints:
+    - `/` – landing page prompting the user to "Connect with Polar".
+    - `/authorize` – starts OAuth2 authorization by redirecting to Polar's auth endpoint, storing a CSRF `state` in KV.
+    - `/callback` – handles the OAuth2 redirect, verifies `state`, exchanges `code` for an access token, registers the user with AccessLink, persists a session in KV, and returns an HTML page with the MCP server URL.
+    - `/mcp` (and `/sse`) – MCP HTTP/SSE endpoint. Looks up the session in KV, constructs an MCP server bound to that user's `accessToken`, and passes handling to `agents/mcp`'s `createMcpHandler`.
+
+### Core modules
+
+- `src/index.ts` – Local stdio MCP server
+  - Creates a `McpServer` instance named `"polar-accesslink"` with tools that map directly to Polar AccessLink endpoints (user info, exercises, single exercise, nightly recharge, sleep, daily activity, physical info).
+  - Uses an internal `polarApiRequest` helper (local to this file) that reads `POLAR_ACCESS_TOKEN` from `process.env` and performs authenticated fetches against `https://www.polaraccesslink.com/v3`.
+  - Each tool serializes Polar responses as pretty-printed JSON text in the MCP tool result.
+
+- `src/worker.ts` – Cloudflare Worker MCP server
+  - Defines an `Env` interface to type Worker bindings (secrets + KV namespace).
+  - Implements `createPolarServer(accessToken)` which returns a `McpServer` wired up with the same conceptual tools as the local server, but parameterized by a provided access token rather than reading from process env.
+  - Uses the shared `polarApiRequest` from `src/polar-api.ts` so HTTP logic is centralized.
+  - Uses the `agents` package's `createMcpHandler` adapter to present the MCP server over HTTP/SSE within the Worker environment.
+  - Contains embedded HTML templates (`landingPageHtml`, `successPageHtml`) for the landing and post-auth pages, including guidance on how to plug the MCP URL into Claude's UI.
+
+- `src/polar-api.ts` – Shared Polar API helpers and tool metadata
+  - Centralizes constants for Polar endpoints (`POLAR_API_BASE`, `POLAR_AUTH_URL`, `POLAR_TOKEN_URL`).
+  - Exposes a generic `polarApiRequest(endpoint, accessToken, options)` used by the Worker-based server.
+  - Implements `exchangeCodeForToken` and `registerPolarUser` utilities that mirror the OAuth/token and user registration flows.
+  - Provides a `POLAR_TOOLS` object containing tool metadata (names, descriptions, JSON input schemas) that can be reused by different MCP surfaces.
+  - Defines `executePolarTool(toolName, args, accessToken)`, which routes a logical MCP tool invocation to the corresponding Polar HTTP call and wraps the result in the standard MCP text content structure. This is the main abstraction point if you want to add or modify tools in a single place.
+
+- `src/auth.ts` – Local OAuth helper CLI
+  - Node-based CLI script to obtain a Polar access token for local development (stdout-friendly, no MCP wiring).
+  - Starts a simple `http` server on `http://localhost:8888/callback`, instructs the user to open the Polar authorization URL, and exchanges the returned `code` for an access token.
+  - Attempts to register the user with AccessLink, then prints the access token along with ready-to-copy `export POLAR_ACCESS_TOKEN=...` and Claude Desktop config snippets.
+
+### TypeScript configuration
+
+- `tsconfig.json`
+  - Targets `ES2022`, `module: "NodeNext"`, `moduleResolution: "NodeNext"` for the Node/stdio entry.
+  - Compiles `src/**/*` to `dist/`, with `rootDir` set to `src`.
+  - Excludes `src/worker.ts` (the Worker entry is handled separately) and common output directories (`node_modules`, `dist`).
+
+- `tsconfig.worker.json`
+  - Worker-specific config using `module: "ESNext"` and `moduleResolution: "bundler"`, with `types: ["@cloudflare/workers-types"]` and `lib: ["ES2022"]`.
+  - Includes only the Worker-related files: `src/worker.ts` and `src/polar-api.ts`.
+
+### How to extend the MCP tools safely
+
+When adding or modifying tools:
+
+- Prefer to update `POLAR_TOOLS` and `executePolarTool` in `src/polar-api.ts` first, so tool metadata and behavior stay in sync across deployment modes.
+- For the local server (`src/index.ts`) and Worker server (`src/worker.ts`), mirror any new tool definitions so that both environments offer a consistent surface area.
+- Ensure any new Polar endpoints respect the existing error-handling pattern: check `response.ok`, include the HTTP status and body text in thrown errors, and return pretty-printed JSON in MCP responses.

--- a/src/auth/oauth-utils.ts
+++ b/src/auth/oauth-utils.ts
@@ -1,0 +1,121 @@
+import type { Env } from "../types.js";
+import { POLAR_AUTH_URL } from "../polar-api.js";
+
+const COOKIE_NAME = "mcp-polar-approved";
+
+export function renderApprovalDialog(
+  oauthReqInfo: { clientId: string; redirectUri: string },
+  stateKey: string
+): Response {
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Authorize - Polar MCP Server</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 500px; margin: 0 auto; padding: 40px 20px; line-height: 1.6; background: #fafafa; }
+    .card { background: white; border-radius: 12px; padding: 32px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+    h1 { color: #d93636; margin: 0 0 8px 0; font-size: 24px; }
+    .subtitle { color: #666; margin: 0 0 24px 0; }
+    .info { background: #f8f9fa; border-radius: 8px; padding: 16px; margin: 16px 0; font-size: 14px; }
+    .info dt { font-weight: 600; color: #333; }
+    .info dd { margin: 0 0 8px 0; color: #666; }
+    .btn { display: inline-block; background: #d93636; color: white; padding: 12px 24px; border: none; border-radius: 8px; font-weight: 600; font-size: 16px; cursor: pointer; transition: background 0.2s; }
+    .btn:hover { background: #b82e2e; }
+    .actions { margin-top: 24px; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Polar MCP Server</h1>
+    <p class="subtitle">An application wants to access your Polar fitness data</p>
+
+    <dl class="info">
+      <dt>Application</dt>
+      <dd>${escapeHtml(oauthReqInfo.clientId)}</dd>
+      <dt>Redirect URI</dt>
+      <dd>${escapeHtml(oauthReqInfo.redirectUri)}</dd>
+    </dl>
+
+    <p>This will allow the application to read your Polar fitness data including exercises, sleep, heart rate, and recovery metrics.</p>
+
+    <form method="POST" action="/authorize">
+      <input type="hidden" name="state_key" value="${escapeHtml(stateKey)}" />
+      <div class="actions">
+        <button type="submit" name="action" value="approve" class="btn">Authorize with Polar</button>
+      </div>
+    </form>
+  </div>
+</body>
+</html>`;
+
+  return new Response(html, {
+    headers: { "Content-Type": "text/html" },
+  });
+}
+
+export function getUpstreamAuthorizeUrl(env: Env, callbackUrl: string, state: string): string {
+  const url = new URL(POLAR_AUTH_URL);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", env.POLAR_CLIENT_ID);
+  url.searchParams.set("redirect_uri", callbackUrl);
+  url.searchParams.set("state", state);
+  return url.toString();
+}
+
+export async function fetchPolarToken(
+  code: string,
+  redirectUri: string,
+  env: Env
+): Promise<{ access_token: string; x_user_id: number }> {
+  const credentials = btoa(`${env.POLAR_CLIENT_ID}:${env.POLAR_CLIENT_SECRET}`);
+
+  const response = await fetch("https://polarremote.com/v2/oauth2/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${credentials}`,
+      Accept: "application/json",
+    },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+    }).toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Polar token exchange failed (${response.status}): ${errorText}`);
+  }
+
+  return response.json() as Promise<{ access_token: string; x_user_id: number }>;
+}
+
+export function clientIdAlreadyApproved(request: Request, clientId: string): boolean {
+  const cookie = request.headers.get("Cookie") || "";
+  return cookie.includes(`${COOKIE_NAME}=${clientId}`);
+}
+
+export function setApprovalCookie(response: Response, clientId: string): Response {
+  const headers = new Headers(response.headers);
+  headers.append(
+    "Set-Cookie",
+    `${COOKIE_NAME}=${clientId}; HttpOnly; Secure; SameSite=Lax; Max-Age=31536000; Path=/`
+  );
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/src/auth/polar-handler.ts
+++ b/src/auth/polar-handler.ts
@@ -1,0 +1,196 @@
+import { Hono } from "hono";
+import type { Env } from "../types.js";
+import { registerPolarUser } from "../polar-api.js";
+import {
+  renderApprovalDialog,
+  getUpstreamAuthorizeUrl,
+  fetchPolarToken,
+  clientIdAlreadyApproved,
+  setApprovalCookie,
+} from "./oauth-utils.js";
+
+const app = new Hono<{ Bindings: Env }>();
+
+// Landing page
+app.get("/", (c) => {
+  const origin = new URL(c.req.url).origin;
+  return c.html(landingPageHtml(origin));
+});
+
+// GET /authorize - Parse OAuth request, show approval dialog or auto-redirect
+app.get("/authorize", async (c) => {
+  // Parse the OAuth authorization request (extracts clientId, redirectUri, state, PKCE, etc.)
+  const authRequest = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
+
+  // Store the full AuthRequest in KV so we can retrieve it after the Polar callback
+  const stateKey = crypto.randomUUID();
+  await c.env.OAUTH_KV.put(
+    `auth_request:${stateKey}`,
+    JSON.stringify(authRequest),
+    { expirationTtl: 600 }
+  );
+
+  const oauthReqInfo = {
+    clientId: authRequest.clientId,
+    redirectUri: authRequest.redirectUri,
+  };
+
+  const alreadyApproved = clientIdAlreadyApproved(c.req.raw, authRequest.clientId);
+
+  if (alreadyApproved) {
+    return redirectToPolar(c, stateKey);
+  }
+
+  return renderApprovalDialog(oauthReqInfo, stateKey);
+});
+
+// POST /authorize - Process approval form, redirect to Polar
+app.post("/authorize", async (c) => {
+  const formData = await c.req.formData();
+  const stateKey = formData.get("state_key") as string;
+
+  // Retrieve auth request to get client_id for the cookie
+  const authRequestStr = await c.env.OAUTH_KV.get(`auth_request:${stateKey}`);
+  if (!authRequestStr) {
+    return c.text("Session expired, please try again", 400);
+  }
+  const authRequest = JSON.parse(authRequestStr);
+
+  const response = await redirectToPolar(c, stateKey);
+  return setApprovalCookie(response, authRequest.clientId);
+});
+
+// GET /callback - Exchange Polar code for token, complete OAuth authorization
+app.get("/callback", async (c) => {
+  const code = c.req.query("code");
+  const polarState = c.req.query("state");
+  const error = c.req.query("error");
+
+  if (error) {
+    return c.text(`OAuth Error: ${error}`, 400);
+  }
+
+  if (!code || !polarState) {
+    return c.text("Missing code or state", 400);
+  }
+
+  // Retrieve stored state (contains our stateKey for the AuthRequest)
+  const stateDataStr = await c.env.OAUTH_KV.get(`state:${polarState}`);
+  if (!stateDataStr) {
+    return c.text("Invalid or expired state", 400);
+  }
+  await c.env.OAUTH_KV.delete(`state:${polarState}`);
+
+  const stateData = JSON.parse(stateDataStr) as { stateKey: string };
+
+  // Retrieve the original AuthRequest
+  const authRequestStr = await c.env.OAUTH_KV.get(`auth_request:${stateData.stateKey}`);
+  if (!authRequestStr) {
+    return c.text("Auth session expired, please try again", 400);
+  }
+  await c.env.OAUTH_KV.delete(`auth_request:${stateData.stateKey}`);
+
+  const authRequest = JSON.parse(authRequestStr);
+
+  // Exchange code for Polar access token
+  const callbackUrl = `${new URL(c.req.url).origin}/callback`;
+  const tokenData = await fetchPolarToken(code, callbackUrl, c.env);
+
+  // Register user with Polar AccessLink (ignore if already registered)
+  await registerPolarUser(tokenData.access_token, tokenData.x_user_id);
+
+  // Complete the OAuth authorization directly — no redirect workaround needed
+  const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
+    request: authRequest,
+    userId: String(tokenData.x_user_id),
+    metadata: {
+      label: `Polar User ${tokenData.x_user_id}`,
+    },
+    scope: authRequest.scope || [],
+    props: {
+      accessToken: tokenData.access_token,
+      userId: tokenData.x_user_id,
+    },
+  });
+
+  return Response.redirect(redirectTo, 302);
+});
+
+// Helper: Store stateKey and redirect to Polar OAuth
+async function redirectToPolar(c: any, stateKey: string) {
+  const url = new URL(c.req.url);
+
+  const callbackState = crypto.randomUUID();
+  await c.env.OAUTH_KV.put(
+    `state:${callbackState}`,
+    JSON.stringify({ stateKey }),
+    { expirationTtl: 600 }
+  );
+
+  const callbackUrl = `${url.origin}/callback`;
+  const upstreamUrl = getUpstreamAuthorizeUrl(c.env, callbackUrl, callbackState);
+  return c.redirect(upstreamUrl);
+}
+
+function landingPageHtml(origin: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <title>Polar MCP Server</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; line-height: 1.6; background: #fafafa; }
+    h1 { color: #d93636; margin-bottom: 8px; }
+    .subtitle { color: #666; margin-top: 0; }
+    .features { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin: 32px 0; }
+    .feature { background: white; border-radius: 12px; padding: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+    .feature h3 { margin: 0 0 8px 0; color: #333; font-size: 16px; }
+    .feature p { margin: 0; color: #666; font-size: 14px; }
+    .steps { background: white; border-radius: 12px; padding: 24px; margin: 24px 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+    .steps h2 { margin-top: 0; }
+    .steps ol { padding-left: 24px; }
+    .steps li { margin: 12px 0; }
+    code { background: #f1f5f9; padding: 2px 8px; border-radius: 4px; font-size: 14px; }
+    .devices { color: #666; font-size: 14px; margin-top: 32px; }
+  </style>
+</head>
+<body>
+  <h1>Polar MCP Server</h1>
+  <p class="subtitle">Connect your Polar fitness data to Claude AI</p>
+
+  <div class="features">
+    <div class="feature">
+      <h3>Exercises</h3>
+      <p>Training data with heart rate, speed, and zone analysis</p>
+    </div>
+    <div class="feature">
+      <h3>Sleep</h3>
+      <p>Sleep stages, sleep score, and quality metrics</p>
+    </div>
+    <div class="feature">
+      <h3>Nightly Recharge</h3>
+      <p>HRV, ANS charge, and recovery status</p>
+    </div>
+    <div class="feature">
+      <h3>Daily Activity</h3>
+      <p>Steps, calories, and activity goals</p>
+    </div>
+  </div>
+
+  <div class="steps">
+    <h2>How it works</h2>
+    <ol>
+      <li>In Claude, go to <strong>Settings → Integrations → Add MCP Server</strong></li>
+      <li>Enter the URL: <code>${origin}/mcp</code></li>
+      <li>Claude will open an authorization window — log in with your Polar account</li>
+      <li>Start chatting about your fitness data!</li>
+    </ol>
+  </div>
+
+  <p class="devices"><strong>Supported devices:</strong> Polar Pacer Pro, Vantage V2/V3, Grit X Pro, Ignite 3, and more.</p>
+</body>
+</html>`;
+}
+
+export const PolarHandler = app;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+import type { OAuthHelpers } from "@cloudflare/workers-oauth-provider";
+
+export interface Props {
+  accessToken: string;
+  userId: number;
+}
+
+export interface Env {
+  POLAR_CLIENT_ID: string;
+  POLAR_CLIENT_SECRET: string;
+  OAUTH_KV: KVNamespace;
+  MCP_OBJECT: DurableObjectNamespace;
+  OAUTH_PROVIDER: OAuthHelpers;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,904 +1,660 @@
 /**
  * Polar MCP Server - Cloudflare Worker (Remote)
  *
- * This is a remote MCP server that can be connected directly from Claude.ai
- * It handles OAuth authentication with Polar AccessLink API.
+ * Uses @cloudflare/workers-oauth-provider + McpAgent for native OAuth.
+ * Users just add the /mcp URL to Claude and auth is handled automatically.
  */
 
 /// <reference types="@cloudflare/workers-types" />
 
-import { createMcpHandler } from "agents/mcp";
+import OAuthProvider from "@cloudflare/workers-oauth-provider";
+import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  polarApiRequest,
-  POLAR_AUTH_URL,
-  POLAR_TOKEN_URL,
-} from "./polar-api.js";
+import { polarApiRequest } from "./polar-api.js";
+import { PolarHandler } from "./auth/polar-handler.js";
+import type { Env, Props } from "./types.js";
 
-export interface Env {
-  POLAR_CLIENT_ID: string;
-  POLAR_CLIENT_SECRET: string;
-  OAUTH_KV: KVNamespace;
-}
+export { Env, Props };
 
-// Create a function to build the MCP server with the access token and user ID
-function createPolarServer(accessToken: string, userId: number): McpServer {
-  const server = new McpServer({
+export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
+  server = new McpServer({
     name: "Polar AccessLink",
     version: "1.0.0",
   });
 
-  // Tool: Get User Info
-  server.tool(
-    "get_user_info",
-    "Get information about the registered Polar user including name, weight, height, birthdate, and other profile data",
-    {},
-    async () => {
-      try {
-        const result = await polarApiRequest(`/users/${userId}`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
+  async init() {
+    const accessToken = this.props.accessToken;
 
-  // Tool: Get Exercises
-  server.tool(
-    "get_exercises",
-    "Get exercise data from Polar. Returns exercises from the last 30 days. Can include detailed samples and training zones.",
-    {
-      samples: z.boolean().optional().describe("Include detailed sample data (heart rate, speed, etc.)"),
-      zones: z.boolean().optional().describe("Include heart rate zone information"),
-    },
-    async ({ samples, zones }) => {
-      try {
-        const params = new URLSearchParams();
-        if (samples) params.append("samples", "true");
-        if (zones) params.append("zones", "true");
-        const queryString = params.toString();
-        const endpoint = `/exercises${queryString ? `?${queryString}` : ""}`;
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Single Exercise
-  server.tool(
-    "get_exercise",
-    "Get detailed data for a specific exercise by ID.",
-    {
-      exerciseId: z.string().describe("The exercise ID to retrieve"),
-      samples: z.boolean().optional().describe("Include detailed sample data"),
-      zones: z.boolean().optional().describe("Include heart rate zone information"),
-    },
-    async ({ exerciseId, samples, zones }) => {
-      try {
-        const params = new URLSearchParams();
-        if (samples) params.append("samples", "true");
-        if (zones) params.append("zones", "true");
-        const queryString = params.toString();
-        const endpoint = `/exercises/${exerciseId}${queryString ? `?${queryString}` : ""}`;
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Nightly Recharge
-  server.tool(
-    "get_nightly_recharge",
-    "Get Nightly Recharge data: ANS charge, HRV, breathing rate, recovery status. Data from the last 28 days.",
-    {
-      date: z.string().optional().describe("Date in YYYY-MM-DD format"),
-    },
-    async ({ date }) => {
-      try {
-        let endpoint = "/users/nightly-recharge";
-        if (date) endpoint = `/users/nightly-recharge/${date}`;
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Sleep
-  server.tool(
-    "get_sleep",
-    "Get sleep tracking data: sleep stages, sleep score, duration, interruptions.",
-    {
-      date: z.string().optional().describe("Date in YYYY-MM-DD format"),
-    },
-    async ({ date }) => {
-      try {
-        let endpoint = "/users/sleep";
-        if (date) endpoint = `/users/sleep/${date}`;
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Daily Activity
-  server.tool(
-    "get_daily_activity",
-    "Get daily activity: steps, calories, active time, activity goals.",
-    {
-      date: z.string().optional().describe("Date in YYYY-MM-DD format"),
-    },
-    async ({ date }) => {
-      try {
-        let endpoint = "/users/activities";
-        if (date) endpoint = `/users/activities/${date}`;
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Physical Info
-  server.tool(
-    "get_physical_info",
-    "Get physical info: weight, height, max heart rate, resting HR, VO2max.",
-    {},
-    async () => {
-      try {
-        const result = await polarApiRequest("/users/physical-information", accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Continuous Heart Rate
-  server.tool(
-    "get_continuous_heart_rate",
-    "Get continuous heart rate data (5-min intervals) for a specific date.",
-    {
-      date: z.string().describe("Date (YYYY-MM-DD format). Required."),
-    },
-    async ({ date }) => {
-      try {
-        const result = await polarApiRequest(`/users/continuous-heart-rate/${date}`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Continuous Heart Rate Range
-  server.tool(
-    "get_continuous_heart_rate_range",
-    "Get continuous heart rate data for a date range.",
-    {
-      from: z.string().describe("Start date (YYYY-MM-DD). Required."),
-      to: z.string().describe("End date (YYYY-MM-DD). Required."),
-    },
-    async ({ from, to }) => {
-      try {
-        const params = new URLSearchParams({ from, to });
-        const result = await polarApiRequest(`/users/continuous-heart-rate?${params.toString()}`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Cardio Load
-  server.tool(
-    "get_cardio_load",
-    "Get cardio load (TRIMP) data: acute load, chronic load, load status.",
-    {
-      date: z.string().optional().describe("Date (YYYY-MM-DD). Optional."),
-    },
-    async ({ date }) => {
-      try {
-        const endpoint = date ? `/users/cardio-load/${date}` : "/users/cardio-load";
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Cardio Load Range
-  server.tool(
-    "get_cardio_load_range",
-    "Get cardio load data for a date range.",
-    {
-      from: z.string().describe("Start date (YYYY-MM-DD). Required."),
-      to: z.string().describe("End date (YYYY-MM-DD). Required."),
-    },
-    async ({ from, to }) => {
-      try {
-        const params = new URLSearchParams({ from, to });
-        const result = await polarApiRequest(`/users/cardio-load/date?${params.toString()}`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Cardio Load History
-  server.tool(
-    "get_cardio_load_history",
-    "Get historical cardio load aggregated by days or months.",
-    {
-      period_type: z.enum(["days", "months"]).describe("'days' or 'months'. Required."),
-      count: z.number().describe("Number of periods. Required."),
-    },
-    async ({ period_type, count }) => {
-      try {
-        const result = await polarApiRequest(`/users/cardio-load/period/${period_type}/${count}`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Activity Samples
-  server.tool(
-    "get_activity_samples",
-    "Get detailed activity samples: step counts and activity zones throughout the day.",
-    {
-      date: z.string().optional().describe("Date (YYYY-MM-DD). Optional."),
-    },
-    async ({ date }) => {
-      try {
-        const endpoint = date ? `/users/activities/samples/${date}` : "/users/activities/samples";
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get Activity Samples Range
-  server.tool(
-    "get_activity_samples_range",
-    "Get activity samples for a date range (max 28 days).",
-    {
-      from: z.string().describe("Start date (YYYY-MM-DD). Required."),
-      to: z.string().describe("End date (YYYY-MM-DD). Required."),
-    },
-    async ({ from, to }) => {
-      try {
-        const params = new URLSearchParams({ from, to });
-        const result = await polarApiRequest(`/users/activities/samples?${params.toString()}`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool: Get SleepWise Alertness
-  server.tool(
-    "get_sleepwise_alertness",
-    "Get SleepWise alertness predictions based on sleep patterns.",
-    {
-      from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
-      to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
-    },
-    async ({ from, to }) => {
-      try {
-        let endpoint = "/users/sleepwise/alertness";
-        if (from || to) {
-          const params = new URLSearchParams();
-          if (from) params.append("from", from);
-          if (to) params.append("to", to);
-          endpoint = `/users/sleepwise/alertness/date?${params.toString()}`;
+    // Tool: Get User Info
+    this.server.tool(
+      "get_user_info",
+      "Get information about the registered Polar user including name, weight, height, birthdate, and other profile data",
+      {},
+      async () => {
+        try {
+          const result = await polarApiRequest("/users/me", accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
         }
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
       }
-    }
-  );
+    );
 
-  // Tool: Get SleepWise Circadian Bedtime
-  server.tool(
-    "get_sleepwise_circadian_bedtime",
-    "Get optimal bedtime recommendations based on circadian rhythm.",
-    {
-      from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
-      to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
-    },
-    async ({ from, to }) => {
-      try {
-        let endpoint = "/users/sleepwise/circadian-bedtime";
-        if (from || to) {
+    // Tool: Get Exercises
+    this.server.tool(
+      "get_exercises",
+      "Get exercise data from Polar. Returns exercises from the last 30 days. Can include detailed samples and training zones.",
+      {
+        samples: z.boolean().optional().describe("Include detailed sample data (heart rate, speed, etc.)"),
+        zones: z.boolean().optional().describe("Include heart rate zone information"),
+      },
+      async ({ samples, zones }) => {
+        try {
           const params = new URLSearchParams();
-          if (from) params.append("from", from);
-          if (to) params.append("to", to);
-          endpoint = `/users/sleepwise/circadian-bedtime/date?${params.toString()}`;
+          if (samples) params.append("samples", "true");
+          if (zones) params.append("zones", "true");
+          const queryString = params.toString();
+          const endpoint = `/exercises${queryString ? `?${queryString}` : ""}`;
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
         }
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
       }
-    }
-  );
+    );
 
-  // Tool: Get Body Temperature
-  server.tool(
-    "get_body_temperature",
-    "Get body temperature data from Elixir biosensing.",
-    {
-      from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
-      to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
-    },
-    async ({ from, to }) => {
-      try {
-        let endpoint = "/users/biosensing/bodytemperature";
-        if (from || to) {
+    // Tool: Get Single Exercise
+    this.server.tool(
+      "get_exercise",
+      "Get detailed data for a specific exercise by ID.",
+      {
+        exerciseId: z.string().describe("The exercise ID to retrieve"),
+        samples: z.boolean().optional().describe("Include detailed sample data"),
+        zones: z.boolean().optional().describe("Include heart rate zone information"),
+      },
+      async ({ exerciseId, samples, zones }) => {
+        try {
           const params = new URLSearchParams();
-          if (from) params.append("from", from);
-          if (to) params.append("to", to);
-          endpoint = `${endpoint}?${params.toString()}`;
+          if (samples) params.append("samples", "true");
+          if (zones) params.append("zones", "true");
+          const queryString = params.toString();
+          const endpoint = `/exercises/${exerciseId}${queryString ? `?${queryString}` : ""}`;
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
         }
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
       }
-    }
-  );
+    );
 
-  // Tool: Get Skin Temperature
-  server.tool(
-    "get_skin_temperature",
-    "Get sleep skin temperature data from Elixir biosensing.",
-    {
-      from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
-      to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
-    },
-    async ({ from, to }) => {
-      try {
-        let endpoint = "/users/biosensing/skintemperature";
-        if (from || to) {
-          const params = new URLSearchParams();
-          if (from) params.append("from", from);
-          if (to) params.append("to", to);
-          endpoint = `${endpoint}?${params.toString()}`;
+    // Tool: Get Nightly Recharge
+    this.server.tool(
+      "get_nightly_recharge",
+      "Get Nightly Recharge data: ANS charge, HRV, breathing rate, recovery status. Data from the last 28 days.",
+      {
+        date: z.string().optional().describe("Date in YYYY-MM-DD format"),
+      },
+      async ({ date }) => {
+        try {
+          let endpoint = "/users/nightly-recharge";
+          if (date) endpoint = `/users/nightly-recharge/${date}`;
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
         }
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
       }
-    }
-  );
+    );
 
-  // Tool: Get SpO2
-  server.tool(
-    "get_spo2",
-    "Get SpO2 (blood oxygen) test results from Elixir biosensing.",
-    {
-      from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
-      to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
-    },
-    async ({ from, to }) => {
-      try {
-        let endpoint = "/users/biosensing/spo2";
-        if (from || to) {
-          const params = new URLSearchParams();
-          if (from) params.append("from", from);
-          if (to) params.append("to", to);
-          endpoint = `${endpoint}?${params.toString()}`;
+    // Tool: Get Sleep
+    this.server.tool(
+      "get_sleep",
+      "Get sleep tracking data: sleep stages, sleep score, duration, interruptions.",
+      {
+        date: z.string().optional().describe("Date in YYYY-MM-DD format"),
+      },
+      async ({ date }) => {
+        try {
+          let endpoint = "/users/sleep";
+          if (date) endpoint = `/users/sleep/${date}`;
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
         }
-        const result = await polarApiRequest(endpoint, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
       }
-    }
-  );
+    );
 
-  // Tool: Get Exercise FIT
-  server.tool(
-    "get_exercise_fit",
-    "Download exercise in FIT format.",
-    {
-      exerciseId: z.string().describe("Exercise ID. Required."),
-    },
-    async ({ exerciseId }) => {
-      try {
-        const result = await polarApiRequest(`/exercises/${exerciseId}/fit`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
+    // Tool: Get Daily Activity
+    this.server.tool(
+      "get_daily_activity",
+      "Get daily activity: steps, calories, active time, activity goals.",
+      {
+        date: z.string().optional().describe("Date in YYYY-MM-DD format"),
+      },
+      async ({ date }) => {
+        try {
+          let endpoint = "/users/activities";
+          if (date) endpoint = `/users/activities/${date}`;
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
       }
-    }
-  );
+    );
 
-  // Tool: Get Exercise TCX
-  server.tool(
-    "get_exercise_tcx",
-    "Download exercise in TCX format.",
-    {
-      exerciseId: z.string().describe("Exercise ID. Required."),
-    },
-    async ({ exerciseId }) => {
-      try {
-        const result = await polarApiRequest(`/exercises/${exerciseId}/tcx`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
+    // Tool: Get Physical Info
+    this.server.tool(
+      "get_physical_info",
+      "Get physical info: weight, height, max heart rate, resting HR, VO2max.",
+      {},
+      async () => {
+        try {
+          const result = await polarApiRequest("/users/physical-information", accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
       }
-    }
-  );
+    );
 
-  // Tool: Get Exercise GPX
-  server.tool(
-    "get_exercise_gpx",
-    "Download exercise GPS route in GPX format.",
-    {
-      exerciseId: z.string().describe("Exercise ID. Required."),
-    },
-    async ({ exerciseId }) => {
-      try {
-        const result = await polarApiRequest(`/exercises/${exerciseId}/gpx`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
+    // Tool: Get Continuous Heart Rate
+    this.server.tool(
+      "get_continuous_heart_rate",
+      "Get continuous heart rate data (5-min intervals) for a specific date.",
+      {
+        date: z.string().describe("Date (YYYY-MM-DD format). Required."),
+      },
+      async ({ date }) => {
+        try {
+          const result = await polarApiRequest(`/users/continuous-heart-rate/${date}`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
       }
-    }
-  );
+    );
 
-  // Tool: Get Daily Activity Range
-  server.tool(
-    "get_daily_activity_range",
-    "Get daily activity data for a date range.",
-    {
-      from: z.string().describe("Start date (YYYY-MM-DD). Required."),
-      to: z.string().describe("End date (YYYY-MM-DD). Required."),
-    },
-    async ({ from, to }) => {
-      try {
-        const params = new URLSearchParams({ from, to });
-        const result = await polarApiRequest(`/users/activities?${params.toString()}`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
+    // Tool: Get Continuous Heart Rate Range
+    this.server.tool(
+      "get_continuous_heart_rate_range",
+      "Get continuous heart rate data for a date range.",
+      {
+        from: z.string().describe("Start date (YYYY-MM-DD). Required."),
+        to: z.string().describe("End date (YYYY-MM-DD). Required."),
+      },
+      async ({ from, to }) => {
+        try {
+          const params = new URLSearchParams({ from, to });
+          const result = await polarApiRequest(`/users/continuous-heart-rate?${params.toString()}`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
       }
-    }
-  );
+    );
 
-  // Tool: Get Sleep Range
-  server.tool(
-    "get_sleep_range",
-    "Get sleep data for a date range.",
-    {
-      from: z.string().describe("Start date (YYYY-MM-DD). Required."),
-      to: z.string().describe("End date (YYYY-MM-DD). Required."),
-    },
-    async ({ from, to }) => {
-      try {
-        const params = new URLSearchParams({ from, to });
-        const result = await polarApiRequest(`/users/sleep?${params.toString()}`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
+    // Tool: Get Cardio Load
+    this.server.tool(
+      "get_cardio_load",
+      "Get cardio load (TRIMP) data: acute load, chronic load, load status.",
+      {
+        date: z.string().optional().describe("Date (YYYY-MM-DD). Optional."),
+      },
+      async ({ date }) => {
+        try {
+          const endpoint = date ? `/users/cardio-load/${date}` : "/users/cardio-load";
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
       }
-    }
-  );
+    );
 
-  // Tool: Get Nightly Recharge Range
-  server.tool(
-    "get_nightly_recharge_range",
-    "Get Nightly Recharge data for a date range.",
-    {
-      from: z.string().describe("Start date (YYYY-MM-DD). Required."),
-      to: z.string().describe("End date (YYYY-MM-DD). Required."),
-    },
-    async ({ from, to }) => {
-      try {
-        const params = new URLSearchParams({ from, to });
-        const result = await polarApiRequest(`/users/nightly-recharge?${params.toString()}`, accessToken);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-          isError: true,
-        };
+    // Tool: Get Cardio Load Range
+    this.server.tool(
+      "get_cardio_load_range",
+      "Get cardio load data for a date range.",
+      {
+        from: z.string().describe("Start date (YYYY-MM-DD). Required."),
+        to: z.string().describe("End date (YYYY-MM-DD). Required."),
+      },
+      async ({ from, to }) => {
+        try {
+          const params = new URLSearchParams({ from, to });
+          const result = await polarApiRequest(`/users/cardio-load/date?${params.toString()}`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
       }
-    }
-  );
+    );
 
-  return server;
+    // Tool: Get Cardio Load History
+    this.server.tool(
+      "get_cardio_load_history",
+      "Get historical cardio load aggregated by days or months.",
+      {
+        period_type: z.enum(["days", "months"]).describe("'days' or 'months'. Required."),
+        count: z.number().describe("Number of periods. Required."),
+      },
+      async ({ period_type, count }) => {
+        try {
+          const result = await polarApiRequest(`/users/cardio-load/period/${period_type}/${count}`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Activity Samples
+    this.server.tool(
+      "get_activity_samples",
+      "Get detailed activity samples: step counts and activity zones throughout the day.",
+      {
+        date: z.string().optional().describe("Date (YYYY-MM-DD). Optional."),
+      },
+      async ({ date }) => {
+        try {
+          const endpoint = date ? `/users/activities/samples/${date}` : "/users/activities/samples";
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Activity Samples Range
+    this.server.tool(
+      "get_activity_samples_range",
+      "Get activity samples for a date range (max 28 days).",
+      {
+        from: z.string().describe("Start date (YYYY-MM-DD). Required."),
+        to: z.string().describe("End date (YYYY-MM-DD). Required."),
+      },
+      async ({ from, to }) => {
+        try {
+          const params = new URLSearchParams({ from, to });
+          const result = await polarApiRequest(`/users/activities/samples?${params.toString()}`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get SleepWise Alertness
+    this.server.tool(
+      "get_sleepwise_alertness",
+      "Get SleepWise alertness predictions based on sleep patterns.",
+      {
+        from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
+        to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
+      },
+      async ({ from, to }) => {
+        try {
+          let endpoint = "/users/sleepwise/alertness";
+          if (from || to) {
+            const params = new URLSearchParams();
+            if (from) params.append("from", from);
+            if (to) params.append("to", to);
+            endpoint = `/users/sleepwise/alertness/date?${params.toString()}`;
+          }
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get SleepWise Circadian Bedtime
+    this.server.tool(
+      "get_sleepwise_circadian_bedtime",
+      "Get optimal bedtime recommendations based on circadian rhythm.",
+      {
+        from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
+        to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
+      },
+      async ({ from, to }) => {
+        try {
+          let endpoint = "/users/sleepwise/circadian-bedtime";
+          if (from || to) {
+            const params = new URLSearchParams();
+            if (from) params.append("from", from);
+            if (to) params.append("to", to);
+            endpoint = `/users/sleepwise/circadian-bedtime/date?${params.toString()}`;
+          }
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Body Temperature
+    this.server.tool(
+      "get_body_temperature",
+      "Get body temperature data from Elixir biosensing.",
+      {
+        from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
+        to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
+      },
+      async ({ from, to }) => {
+        try {
+          let endpoint = "/users/biosensing/bodytemperature";
+          if (from || to) {
+            const params = new URLSearchParams();
+            if (from) params.append("from", from);
+            if (to) params.append("to", to);
+            endpoint = `${endpoint}?${params.toString()}`;
+          }
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Skin Temperature
+    this.server.tool(
+      "get_skin_temperature",
+      "Get sleep skin temperature data from Elixir biosensing.",
+      {
+        from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
+        to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
+      },
+      async ({ from, to }) => {
+        try {
+          let endpoint = "/users/biosensing/skintemperature";
+          if (from || to) {
+            const params = new URLSearchParams();
+            if (from) params.append("from", from);
+            if (to) params.append("to", to);
+            endpoint = `${endpoint}?${params.toString()}`;
+          }
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get SpO2
+    this.server.tool(
+      "get_spo2",
+      "Get SpO2 (blood oxygen) test results from Elixir biosensing.",
+      {
+        from: z.string().optional().describe("Start date (YYYY-MM-DD). Optional."),
+        to: z.string().optional().describe("End date (YYYY-MM-DD). Optional."),
+      },
+      async ({ from, to }) => {
+        try {
+          let endpoint = "/users/biosensing/spo2";
+          if (from || to) {
+            const params = new URLSearchParams();
+            if (from) params.append("from", from);
+            if (to) params.append("to", to);
+            endpoint = `${endpoint}?${params.toString()}`;
+          }
+          const result = await polarApiRequest(endpoint, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Exercise FIT
+    this.server.tool(
+      "get_exercise_fit",
+      "Download exercise in FIT format.",
+      {
+        exerciseId: z.string().describe("Exercise ID. Required."),
+      },
+      async ({ exerciseId }) => {
+        try {
+          const result = await polarApiRequest(`/exercises/${exerciseId}/fit`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Exercise TCX
+    this.server.tool(
+      "get_exercise_tcx",
+      "Download exercise in TCX format.",
+      {
+        exerciseId: z.string().describe("Exercise ID. Required."),
+      },
+      async ({ exerciseId }) => {
+        try {
+          const result = await polarApiRequest(`/exercises/${exerciseId}/tcx`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Exercise GPX
+    this.server.tool(
+      "get_exercise_gpx",
+      "Download exercise GPS route in GPX format.",
+      {
+        exerciseId: z.string().describe("Exercise ID. Required."),
+      },
+      async ({ exerciseId }) => {
+        try {
+          const result = await polarApiRequest(`/exercises/${exerciseId}/gpx`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Daily Activity Range
+    this.server.tool(
+      "get_daily_activity_range",
+      "Get daily activity data for a date range.",
+      {
+        from: z.string().describe("Start date (YYYY-MM-DD). Required."),
+        to: z.string().describe("End date (YYYY-MM-DD). Required."),
+      },
+      async ({ from, to }) => {
+        try {
+          const params = new URLSearchParams({ from, to });
+          const result = await polarApiRequest(`/users/activities?${params.toString()}`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Sleep Range
+    this.server.tool(
+      "get_sleep_range",
+      "Get sleep data for a date range.",
+      {
+        from: z.string().describe("Start date (YYYY-MM-DD). Required."),
+        to: z.string().describe("End date (YYYY-MM-DD). Required."),
+      },
+      async ({ from, to }) => {
+        try {
+          const params = new URLSearchParams({ from, to });
+          const result = await polarApiRequest(`/users/sleep?${params.toString()}`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    // Tool: Get Nightly Recharge Range
+    this.server.tool(
+      "get_nightly_recharge_range",
+      "Get Nightly Recharge data for a date range.",
+      {
+        from: z.string().describe("Start date (YYYY-MM-DD). Required."),
+        to: z.string().describe("End date (YYYY-MM-DD). Required."),
+      },
+      async ({ from, to }) => {
+        try {
+          const params = new URLSearchParams({ from, to });
+          const result = await polarApiRequest(`/users/nightly-recharge?${params.toString()}`, accessToken);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return {
+            content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+            isError: true,
+          };
+        }
+      }
+    );
+  }
 }
 
-// HTML Templates
-const landingPageHtml = (origin: string) => `<!DOCTYPE html>
-<html>
-<head>
-  <title>Polar MCP Server</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    * { box-sizing: border-box; }
-    body { font-family: system-ui, -apple-system, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; line-height: 1.6; background: #fafafa; }
-    h1 { color: #d93636; margin-bottom: 8px; }
-    .subtitle { color: #666; margin-top: 0; }
-    .btn { display: inline-block; background: #d93636; color: white; padding: 14px 28px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px; transition: background 0.2s; }
-    .btn:hover { background: #b82e2e; }
-    .features { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin: 32px 0; }
-    .feature { background: white; border-radius: 12px; padding: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
-    .feature h3 { margin: 0 0 8px 0; color: #333; font-size: 16px; }
-    .feature p { margin: 0; color: #666; font-size: 14px; }
-    .steps { background: white; border-radius: 12px; padding: 24px; margin: 24px 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
-    .steps h2 { margin-top: 0; }
-    .steps ol { padding-left: 24px; }
-    .steps li { margin: 12px 0; }
-    code { background: #f1f5f9; padding: 2px 8px; border-radius: 4px; font-size: 14px; }
-    .devices { color: #666; font-size: 14px; margin-top: 32px; }
-  </style>
-</head>
-<body>
-  <h1>Polar MCP Server</h1>
-  <p class="subtitle">Connect your Polar fitness data to Claude AI</p>
-
-  <p style="margin: 24px 0;"><a href="/authorize" class="btn">Connect with Polar</a></p>
-
-  <div class="features">
-    <div class="feature">
-      <h3>Exercises</h3>
-      <p>Training data with heart rate, speed, and zone analysis</p>
-    </div>
-    <div class="feature">
-      <h3>Sleep</h3>
-      <p>Sleep stages, sleep score, and quality metrics</p>
-    </div>
-    <div class="feature">
-      <h3>Nightly Recharge</h3>
-      <p>HRV, ANS charge, and recovery status</p>
-    </div>
-    <div class="feature">
-      <h3>Daily Activity</h3>
-      <p>Steps, calories, and activity goals</p>
-    </div>
-  </div>
-
-  <div class="steps">
-    <h2>How it works</h2>
-    <ol>
-      <li>Click <strong>"Connect with Polar"</strong> and authorize with your Polar account</li>
-      <li>Copy the MCP Server URL you receive</li>
-      <li>In Claude, go to <strong>Settings → Integrations → Add MCP Server</strong></li>
-      <li>Paste the URL and start chatting about your fitness data!</li>
-    </ol>
-  </div>
-
-  <p class="devices"><strong>Supported devices:</strong> Polar Pacer Pro, Vantage V2/V3, Grit X Pro, Ignite 3, and more.</p>
-</body>
-</html>`;
-
-const successPageHtml = (origin: string, sessionId: string) => `<!DOCTYPE html>
-<html>
-<head>
-  <title>Connected to Polar!</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    * { box-sizing: border-box; }
-    body { font-family: system-ui, -apple-system, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; line-height: 1.6; background: #fafafa; }
-    h1 { color: #22c55e; }
-    .url-box { background: white; border: 2px solid #22c55e; border-radius: 12px; padding: 20px; margin: 24px 0; }
-    .url-box h3 { margin: 0 0 12px 0; color: #333; }
-    .url { background: #f1f5f9; padding: 12px 16px; border-radius: 8px; font-family: monospace; font-size: 14px; word-break: break-all; user-select: all; }
-    .copy-btn { display: inline-block; background: #22c55e; color: white; padding: 10px 20px; border: none; border-radius: 6px; cursor: pointer; font-size: 14px; margin-top: 12px; }
-    .copy-btn:hover { background: #16a34a; }
-    .steps { background: white; border-radius: 12px; padding: 24px; margin: 24px 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
-    .steps ol { padding-left: 24px; }
-    .steps li { margin: 12px 0; }
-    .note { background: #fef3c7; border-radius: 8px; padding: 16px; margin-top: 24px; font-size: 14px; }
-  </style>
-</head>
-<body>
-  <h1>Connected!</h1>
-  <p>Your Polar account is now connected. Add this MCP server to Claude:</p>
-
-  <div class="url-box">
-    <h3>Your MCP Server URL:</h3>
-    <div class="url" id="mcpUrl">${origin}/mcp?session=${sessionId}</div>
-    <button class="copy-btn" onclick="navigator.clipboard.writeText(document.getElementById('mcpUrl').textContent)">Copy URL</button>
-  </div>
-
-  <div class="steps">
-    <h3>Next steps in Claude:</h3>
-    <ol>
-      <li>Go to <strong>Settings → Integrations</strong></li>
-      <li>Click <strong>"Add Integration"</strong> or <strong>"Add MCP Server"</strong></li>
-      <li>Paste the URL above</li>
-      <li>Ask Claude about your fitness data!</li>
-    </ol>
-  </div>
-
-  <div class="note">
-    <strong>Note:</strong> This session expires in 24 hours. To reconnect, visit <a href="${origin}/authorize">${origin}/authorize</a>
-  </div>
-</body>
-</html>`;
-
-// Main Worker
-export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    const url = new URL(request.url);
-
-    // Landing page
-    if (url.pathname === "/" || url.pathname === "") {
-      return new Response(landingPageHtml(url.origin), {
-        headers: { "Content-Type": "text/html" },
-      });
-    }
-
-    // OAuth: Start authorization
-    if (url.pathname === "/authorize") {
-      const redirectUri = `${url.origin}/callback`;
-      const state = crypto.randomUUID();
-
-      // Store state for CSRF protection
-      await env.OAUTH_KV.put(`state:${state}`, "valid", { expirationTtl: 600 });
-
-      const authUrl = new URL(POLAR_AUTH_URL);
-      authUrl.searchParams.set("response_type", "code");
-      authUrl.searchParams.set("client_id", env.POLAR_CLIENT_ID);
-      authUrl.searchParams.set("redirect_uri", redirectUri);
-      authUrl.searchParams.set("state", state);
-
-      return Response.redirect(authUrl.toString(), 302);
-    }
-
-    // OAuth: Handle callback
-    if (url.pathname === "/callback") {
-      const code = url.searchParams.get("code");
-      const state = url.searchParams.get("state");
-      const error = url.searchParams.get("error");
-
-      if (error) {
-        return new Response(`OAuth Error: ${error}`, { status: 400 });
-      }
-
-      if (!code || !state) {
-        return new Response("Missing code or state", { status: 400 });
-      }
-
-      // Verify state
-      const storedState = await env.OAUTH_KV.get(`state:${state}`);
-      if (!storedState) {
-        return new Response("Invalid state - possible CSRF attack", { status: 400 });
-      }
-      await env.OAUTH_KV.delete(`state:${state}`);
-
-      // Exchange code for token
-      const redirectUri = `${url.origin}/callback`;
-      const credentials = btoa(`${env.POLAR_CLIENT_ID}:${env.POLAR_CLIENT_SECRET}`);
-
-      const tokenResponse = await fetch(POLAR_TOKEN_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          Authorization: `Basic ${credentials}`,
-          Accept: "application/json",
-        },
-        body: new URLSearchParams({
-          grant_type: "authorization_code",
-          code: code,
-          redirect_uri: redirectUri,
-        }).toString(),
-      });
-
-      if (!tokenResponse.ok) {
-        const errorText = await tokenResponse.text();
-        return new Response(`Token exchange failed: ${errorText}`, { status: 400 });
-      }
-
-      const tokenData = (await tokenResponse.json()) as {
-        access_token: string;
-        x_user_id: number;
-      };
-
-      // Register user with Polar (ignore if already registered)
-      await fetch("https://www.polaraccesslink.com/v3/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${tokenData.access_token}`,
-          Accept: "application/json",
-        },
-        body: JSON.stringify({
-          "member-id": `mcp_${tokenData.x_user_id}`,
-        }),
-      });
-
-      // Create session
-      const sessionId = crypto.randomUUID();
-      await env.OAUTH_KV.put(
-        `session:${sessionId}`,
-        JSON.stringify({
-          accessToken: tokenData.access_token,
-          userId: tokenData.x_user_id,
-        }),
-        { expirationTtl: 86400 } // 24 hours
-      );
-
-      return new Response(successPageHtml(url.origin, sessionId), {
-        headers: { "Content-Type": "text/html" },
-      });
-    }
-
-    // MCP endpoint
-    if (url.pathname === "/mcp" || url.pathname === "/sse") {
-      const sessionId = url.searchParams.get("session");
-
-      if (!sessionId) {
-        return new Response(
-          JSON.stringify({ error: "Missing session. Please authorize first.", authorize_url: `${url.origin}/authorize` }),
-          { status: 401, headers: { "Content-Type": "application/json" } }
-        );
-      }
-
-      const sessionData = await env.OAUTH_KV.get(`session:${sessionId}`);
-      if (!sessionData) {
-        return new Response(
-          JSON.stringify({ error: "Session expired. Please authorize again.", authorize_url: `${url.origin}/authorize` }),
-          { status: 401, headers: { "Content-Type": "application/json" } }
-        );
-      }
-
-      const { accessToken, userId } = JSON.parse(sessionData);
-
-      // Create MCP server with the user's access token and ID
-      const server = createPolarServer(accessToken, userId);
-
-      // Use Cloudflare's MCP handler
-      const handler = createMcpHandler(server);
-
-      return handler(request, env, ctx);
-    }
-
-    return new Response("Not Found", { status: 404 });
+export default new OAuthProvider({
+  apiHandlers: {
+    "/sse": MyMCP.serveSSE("/sse") as any,
+    "/mcp": MyMCP.serve("/mcp") as any,
   },
-};
+  defaultHandler: PolarHandler as any,
+  authorizeEndpoint: "/authorize",
+  tokenEndpoint: "/token",
+  clientRegistrationEndpoint: "/register",
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/worker.ts"]
+  "exclude": ["node_modules", "dist", "src/worker.ts", "src/types.ts", "src/auth"]
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,10 +3,18 @@ main = "src/worker.ts"
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 
-# KV Namespace for OAuth sessions
+# KV Namespace for OAuth state and tokens
 [[kv_namespaces]]
 binding = "OAUTH_KV"
 id = "1986c08548ae49278a3c6d93c36c38ec"
+
+# Durable Objects for MCP sessions
+[durable_objects]
+bindings = [{ name = "MCP_OBJECT", class_name = "MyMCP" }]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyMCP"]
 
 # Environment variables (set via wrangler secret)
 # wrangler secret put POLAR_CLIENT_ID
@@ -22,3 +30,10 @@ name = "polar-mcp-server-dev"
 [[env.dev.kv_namespaces]]
 binding = "OAUTH_KV"
 id = "YOUR_DEV_KV_NAMESPACE_ID"  # Replace after creating: wrangler kv namespace create OAUTH_KV --env dev
+
+[env.dev.durable_objects]
+bindings = [{ name = "MCP_OBJECT", class_name = "MyMCP" }]
+
+[[env.dev.migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyMCP"]


### PR DESCRIPTION
## Summary

- Replace manual session-based auth with Cloudflare's native `OAuthProvider` + `McpAgent` Durable Object pattern
- Fix "OAuth provider not available" error by using `env.OAUTH_PROVIDER.completeAuthorization()` instead of the broken `request.completeAuthorization` injection
- Add modular `src/auth/` with Polar OAuth handler (Hono) and utilities, `src/types.ts` for shared types
- Rewrite `src/worker.ts` as a `McpAgent` class with `OAuthProvider` default export
- Update `wrangler.toml` with Durable Object bindings/migrations and `tsconfig.json` to exclude worker-only files

## Test plan

- [x] `npm run build` passes (local CLI)
- [x] `npx wrangler deploy --dry-run` passes (worker build)
- [x] Deployed and tested end-to-end: add `/mcp` URL in Claude → approval dialog → Polar login → redirect completes → tools available

🤖 Generated with [Claude Code](https://claude.com/claude-code)