### PR TITLE
fix: Use correct Polar API endpoints for user info and physical info

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -176,14 +176,20 @@ async function main() {
     console.log("");
     console.log(`  ${tokenData.access_token}`);
     console.log("");
-    console.log("Add this to your Claude Desktop config or environment:");
+    console.log("Your user ID:");
+    console.log("");
+    console.log(`  ${tokenData.x_user_id}`);
+    console.log("");
+    console.log("Add these to your environment:");
     console.log("");
     console.log(`  export POLAR_ACCESS_TOKEN="${tokenData.access_token}"`);
+    console.log(`  export POLAR_USER_ID="${tokenData.x_user_id}"`);
     console.log("");
     console.log("Or add to your Claude Desktop config.json:");
     console.log("");
     console.log(`  "env": {`);
-    console.log(`    "POLAR_ACCESS_TOKEN": "${tokenData.access_token}"`);
+    console.log(`    "POLAR_ACCESS_TOKEN": "${tokenData.access_token}",`);
+    console.log(`    "POLAR_USER_ID": "${tokenData.x_user_id}"`);
     console.log(`  }`);
     console.log("");
   } catch (error) {


### PR DESCRIPTION
## Summary

- **Fixed `get_user_info`**: Changed from `/users/me` (non-existent) to `/users/{userId}` across all three entry points (local CLI, worker, shared helper)
- **Fixed `get_physical_info`**: Implemented the required transaction model (POST create → GET list → GET resources → PUT commit) instead of a direct GET that returns 404
- **Added `POLAR_USER_ID` support**: Local CLI reads from env var; worker uses `this.props.userId` from OAuth; auth helper now prints the user ID after successful authentication

Fixes #1

## Test plan

- [ ] Run `npm run build` to verify local CLI compiles
- [ ] Run `npx wrangler deploy --dry-run` to verify worker builds
- [ ] Deploy worker and test `get_user_info` returns user data instead of 404
- [ ] Deploy worker and test `get_physical_info` returns physical info via transaction model
- [ ] Test local CLI with `POLAR_USER_ID` env var set
- [ ] Run `npx tsx src/auth.ts` and verify it prints user ID with setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)